### PR TITLE
fix: skip MarkDrain and sent Event when --skip-drain

### DIFF
--- a/cmd/draino/draino.go
+++ b/cmd/draino/draino.go
@@ -169,7 +169,8 @@ func main() {
 		kubernetes.NewEventRecorder(cs),
 		kubernetes.WithLogger(log),
 		kubernetes.WithDrainBuffer(*drainBuffer),
-		kubernetes.WithConditionsFilter(*conditions))
+		kubernetes.WithConditionsFilter(*conditions),
+		kubernetes.WithSkipDrainEvent(*skipDrain))
 
 	if *dryRun {
 		h = cache.FilteringResourceEventHandler{
@@ -179,7 +180,8 @@ func main() {
 				kubernetes.NewEventRecorder(cs),
 				kubernetes.WithLogger(log),
 				kubernetes.WithDrainBuffer(*drainBuffer),
-				kubernetes.WithConditionsFilter(*conditions)),
+				kubernetes.WithConditionsFilter(*conditions),
+				kubernetes.WithSkipDrainEvent(*skipDrain)),
 		}
 	}
 

--- a/internal/kubernetes/drainSchedule.go
+++ b/internal/kubernetes/drainSchedule.go
@@ -65,7 +65,7 @@ func (d *DrainSchedules) DeleteSchedule(name string) {
 	if s, ok := d.schedules[name]; ok {
 		s.timer.Stop()
 	} else {
-		d.logger.Error("Failed schedule deletion", zap.String("key", name))
+		d.logger.Info("Schedule Not Found", zap.String("key", name))
 	}
 	delete(d.schedules, name)
 }

--- a/internal/kubernetes/drainer.go
+++ b/internal/kubernetes/drainer.go
@@ -224,6 +224,12 @@ func (d *APICordonDrainer) Uncordon(n *core.Node, mutators ...nodeMutatorFn) err
 
 // MarkDrain set a condition on the node to mark that that drain is scheduled.
 func (d *APICordonDrainer) MarkDrain(n *core.Node, when, finish time.Time, failed bool) error {
+	// Do nothing if draining is not enabled.
+	if d.skipDrain {
+		d.l.Debug("Skipping drain because draining is disabled")
+		return nil
+	}
+
 	nodeName := n.Name
 	// Refresh the node object
 	freshNode, err := d.c.CoreV1().Nodes().Get(nodeName, meta.GetOptions{})

--- a/internal/kubernetes/eventhandler.go
+++ b/internal/kubernetes/eventhandler.go
@@ -80,10 +80,18 @@ type DrainingResourceEventHandler struct {
 	buffer                time.Duration
 
 	conditions []SuppliedCondition
+	skipDrain  bool
 }
 
 // DrainingResourceEventHandlerOption configures an DrainingResourceEventHandler.
 type DrainingResourceEventHandlerOption func(d *DrainingResourceEventHandler)
+
+// WithSkipDrainEvent configures if should skip drain in handler
+func WithSkipDrainEvent(skipDrain bool) DrainingResourceEventHandlerOption {
+	return func(h *DrainingResourceEventHandler) {
+		h.skipDrain = skipDrain
+	}
+}
 
 // WithLogger configures a DrainingResourceEventHandler to use the supplied
 // logger.
@@ -165,6 +173,10 @@ func (h *DrainingResourceEventHandler) HandleNode(n *core.Node) {
 	// First cordon the node if it is not yet cordonned
 	if !n.Spec.Unschedulable {
 		h.cordon(n, badConditions)
+	}
+
+	if h.skipDrain {
+		return
 	}
 
 	// Let's ensure that a drain is scheduled


### PR DESCRIPTION
We accept the PR (https://github.com/planetlabs/draino/pull/136) created on upstream.